### PR TITLE
Add contribution guideline file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 1.9.2
+  - 1.8.7
+  - ree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+Contributing
+============
+
+
+Quick Overview
+--------------
+
+We love pull requests. Here's a quick overview of the process (detail below):
+
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, so start with a clean slate.
+
+3. Add a test for your new code. Only refactoring and documentation changes require no new tests. If you are adding functionality or fixing a bug, we need a test!
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+At this point you're waiting on us. We may suggest some changes or improvements or alternatives. Once we approve, we will merge your branch in.
+
+Some things that will increase the chance that your pull request is accepted, taken straight from the Ruby on Rails guide:
+
+* Use Rails idioms and helpers
+* Include tests which fail without your code and pass with it
+* Update the documentation, the surrounding code, examples elsewhere, guides, whatever is affected by your contribution
+
+
+Requirements
+--------------
+
+Please remember this is open-source, so don't commit any passwords or API keys.
+Those should go in config variables like `ENV['API_KEY']`.
+
+
+Laptop setup
+------------
+
+Fork the repo and clone the app:
+
+    git clone git@github.com:[GIT_USERNAME]/sched.do.git
+
+
+Install Bundler 1.2.0.pre or higher:
+
+    gem install bundler --pre
+
+Set up the app:
+
+    cd yam
+    bundle --binstubs
+
+
+Running tests
+-------------
+
+Run the whole test suite with:
+
+    rake
+
+Run individual specs like:
+
+    rspec spec/yam_spec.rb
+
+Tab complete to make it even faster!
+
+When a spec file has many specs, you sometimes want to run just what you're
+working on. In that case, specify a line number:
+
+    rspec spec/yam_spec.rb:9
+
+
+Syntax
+------
+
+* Two spaces, no tabs.
+* No trailing whitespace. Blank lines should not have any spaces.
+* Prefer `&&/||` over `and/or`.
+* `MyClass.my_method(my_arg)` not `my_method( my_arg )` or `my_method my_arg`.
+* `a = b` and not `a=b`.
+* Follow the conventions you see used in the source already.
+
+And in case we didn't emphasize it enough: we love tests!
+
+
+Development process
+-------------------
+
+For details and screenshots of the feature branch code review process,
+read [this blog post](http://robots.thoughtbot.com/post/2831837714/feature-branch-code-reviews).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Yam
+Yam
+===
 
 The official Yammer Ruby gem.
 
-## Installation
+Installation
+------------
 
 Add this line to your application's Gemfile:
 
@@ -22,11 +24,10 @@ Or install it yourself as:
 $ gem install yam
 ```
 
-## General Configuration
+General Configuration
+---------------------
 
 The Yammer API requires you to authenticate via OAuth, so you'll need to register your Yammer application. To register a new application, sign in to Yammer and then fill out the form at https://www.yammer.com/client_applications.
-
-#### Retrieving your Yammer access token
 
 If you already have your access token, you can skip this section.
 
@@ -47,24 +48,23 @@ Sample access token (token is 'abcdefghijklmn' in this example) as part of respo
 
 ```
 “access_token”: {
-“view_subscriptions”: true,
-“expires_at”: null,
-authorized_at”: “2011/04/06 16:25:46 +0000”,
-“modify_subscriptions”: true,
-“modify_messages”: true,
-“network_permalink”: “yammer-inc.com”,
-“view_members”: true,
-“view_tags”: true,
-“network_id”: 155465488,
-“user_id”: 1014216,
-“view_groups”: true,
-“token”: “abcdefghijklmn”,
-“network_name”: “Yammer”,
-“view_messages”: true,
-“created_at”: “2011/04/06 16:25:46 +0000”
+  “view_subscriptions”: true,
+  “expires_at”: null,
+  authorized_at”: “2011/04/06 16:25:46 +0000”,
+  “modify_subscriptions”: true,
+  “modify_messages”: true,
+  “network_permalink”: “yammer-inc.com”,
+  “view_members”: true,
+  “view_tags”: true,
+  “network_id”: 155465488,
+  “user_id”: 1014216,
+  “view_groups”: true,
+  “token”: “abcdefghijklmn”,
+  “network_name”: “Yammer”,
+  “view_messages”: true,
+  “created_at”: “2011/04/06 16:25:46 +0000”
 }
 ```
-#### Set the OAuth Token
 
 Set the OAuth token on your app. Example:
 
@@ -73,7 +73,9 @@ Yam.configure do |config|
   config.oauth_token = your_oauth_token
 end
 ```
-## Rails Configuration
+
+Rails Configuration
+-------------------
 
 Retrieve your access token using the steps outlined in the <a href="#general-configuration">general configuration</a> section above.
 
@@ -85,11 +87,14 @@ Yam.configure do |config|
 end
 ```
 
-#### Set up Yammer OAuth 2.0
+Set up Yammer OAuth 2.0
+-----------------------
 
 See Yammer's Developer Guide for step-by-step instructions on setting up OAuth 2.0: <http://developer.yammer.com/files/2012/10/PlatformDeveloperGuide.pdf>
 
-## Usage Examples
+Usage Examples
+--------------
+
 All examples require an authenticated Yammer client. See the <a
 href="#general-configuration">general configuration</a> section for instructions for finding and setting your access token.
 
@@ -131,10 +136,7 @@ Yam.post('/messages', body: 'this is a group message', group_id: 987654)
 Yam.post('/messages', :body: 'here is my open graph object', og_url: "https://www.yammer.com/example/graph/123456789")
 ```
 
-## Contributing
+Contributing
+------------
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+To contribute to this project, see the [CONTRIBUTING.md](https://github.com/yammer/yam/blob/master/CONTRIBUTING.md) file.


### PR DESCRIPTION
- Add link to `CONTRIBUTING.md` file, as per [GitHub guidelines](https://github.com/blog/1184-contributing-guidelines)
- Clean up markdown syntax
- Indent code example for clarity
- Add `CONTRIBUTING.md` file adapted from sched.do contribution file
