### PR TITLE
Minor cleanup before open-sourcing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Laptop setup
 
 Fork the repo and clone the app:
 
-    git clone git@github.com:[GIT_USERNAME]/sched.do.git
+    git clone git@github.com:[GIT_USERNAME]/yam.git
 
 
 Install Bundler 1.2.0.pre or higher:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Yam
 
 The official Yammer Ruby gem.
 
+NOTE: Currently in alpha - use at your own risk
+
 Installation
 ------------
 

--- a/lib/yam.rb
+++ b/lib/yam.rb
@@ -14,28 +14,24 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
-require "yam/version"
-require "yam/configuration"
-require "yam/client"
+
+require 'yam/version'
+require 'yam/configuration'
+require 'yam/client'
 
 module Yam
   extend Configuration
 
   class << self
-
-    # Handle for the client instance
+    # Handler for the client instance
     attr_accessor :api_client
 
     # Alias for Yam::Client.new
-    #
-    # @return [Yam::Client]
     def new(options = {}, &block)
       @api_client = Yam::Client.new(options, &block)
     end
 
     # Delegate to Yam::Client
-    #
     def method_missing(method, *args, &block)
       return super unless new.respond_to?(method)
       new.send(method, *args, &block)

--- a/lib/yam/configuration.rb
+++ b/lib/yam/configuration.rb
@@ -14,10 +14,9 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
+
 module Yam
   module Configuration
-
     VALID_OPTIONS_KEYS = [
       :adapter,
       :endpoint,
@@ -50,12 +49,11 @@ module Yam
     end
 
     def set_defaults
-      self.adapter            = DEFAULT_ADAPTER
-      self.endpoint           = DEFAULT_ENDPOINT
-      self.oauth_token        = DEFAULT_OAUTH_TOKEN
-      self.user_agent         = DEFAULT_USER_AGENT
+      self.adapter = DEFAULT_ADAPTER
+      self.endpoint = DEFAULT_ENDPOINT
+      self.oauth_token = DEFAULT_OAUTH_TOKEN
+      self.user_agent = DEFAULT_USER_AGENT
       self
     end
-
   end
 end

--- a/lib/yam/version.rb
+++ b/lib/yam/version.rb
@@ -14,7 +14,7 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
+
 module Yam
-  VERSION = "0.0.2"
+  VERSION = '0.0.2'
 end

--- a/yam.gemspec
+++ b/yam.gemspec
@@ -1,13 +1,14 @@
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require 'yam/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "yam"
+  gem.name          = 'yam'
   gem.version       = Yam::VERSION
-  gem.authors       = ["Mason Fischer", "Jessie A. Young"]
-  gem.email         = ["mason@thoughtbot.com", "jessie@apprentice.io"]
+  gem.authors       = ['Mason Fischer', 'Jessie A. Young']
+  gem.email         = ['mason@thoughtbot.com', 'jessie@apprentice.io']
   gem.description   = %q{The official Yammer Ruby gem.}
   gem.summary       = %q{A Ruby wrapper for the Yammer REST API}
   gem.homepage      = %q{https://github.com/yammer/yam}
@@ -15,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
   gem.add_dependency 'hashie', '~> 1.2.0'
   gem.add_dependency 'faraday', '~> 0.8.1'


### PR DESCRIPTION
- Cleanup formatting
- Prefer single quotes when not interpolating
- Correct repo name error in git address for README.md
- Use normal quotes over curly ones
- Add Alpha warning on README.md
