### PR TITLE
Align code with locally stored version

### DIFF
--- a/lib/yam.rb
+++ b/lib/yam.rb
@@ -15,9 +15,9 @@
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 
-require 'yam/version'
-require 'yam/configuration'
 require 'yam/client'
+require 'yam/configuration'
+require 'yam/version'
 
 module Yam
   extend Configuration
@@ -27,18 +27,8 @@ module Yam
     attr_accessor :api_client
 
     # Alias for Yam::Client.new
-    def new(options = {}, &block)
-      @api_client = Yam::Client.new(options, &block)
-    end
-
-    # Delegate to Yam::Client
-    def method_missing(method, *args, &block)
-      return super unless new.respond_to?(method)
-      new.send(method, *args, &block)
-    end
-
-    def respond_to?(method, include_private = false)
-      new.respond_to?(method, include_private) || super(method, include_private)
+    def new(oauth_token, endpoint)
+      @api_client = Yam::Client.new(oauth_token, endpoint)
     end
   end
 end

--- a/lib/yam/api.rb
+++ b/lib/yam/api.rb
@@ -14,7 +14,6 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
 
 # API setup and configuration
 require 'yam/request'
@@ -36,12 +35,15 @@ module Yam
       end
     end
 
-    def initialize(options={}, &block)
-      setup(options)
+    def initialize(oauth_token, endpoint)
+      @oauth_token = oauth_token
+      @endpoint = endpoint
+      setup({})
     end
 
     def setup(options={})
       options = Yam.options.merge(options)
+
       Configuration::VALID_OPTIONS_KEYS.each do |key|
         send("#{key}=", options[key])
       end

--- a/lib/yam/client.rb
+++ b/lib/yam/client.rb
@@ -14,7 +14,7 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
+
 require 'yam/api'
 
 module Yam

--- a/lib/yam/configuration.rb
+++ b/lib/yam/configuration.rb
@@ -17,26 +17,12 @@
 
 module Yam
   module Configuration
-    VALID_OPTIONS_KEYS = [
-      :adapter,
-      :endpoint,
-      :oauth_token,
-      :user_agent,
-    ].freeze
-
     DEFAULT_ADAPTER = :net_http
-
-    DEFAULT_ENDPOINT = 'https://www.yammer.com/api/v1'.freeze
-
-    DEFAULT_OAUTH_TOKEN = nil
-
+    DEFAULT_API_ENDPOINT = 'https://www.yammer.com/api/v1/'
     DEFAULT_USER_AGENT = "Yam Ruby Gem #{Yam::VERSION}".freeze
+    VALID_OPTIONS_KEYS = [:adapter, :endpoint, :user_agent].freeze
 
     attr_accessor *VALID_OPTIONS_KEYS
-
-    def configure
-      yield self
-    end
 
     def self.extended(base)
       base.set_defaults
@@ -50,8 +36,7 @@ module Yam
 
     def set_defaults
       self.adapter = DEFAULT_ADAPTER
-      self.endpoint = DEFAULT_ENDPOINT
-      self.oauth_token = DEFAULT_OAUTH_TOKEN
+      self.endpoint = DEFAULT_API_ENDPOINT
       self.user_agent = DEFAULT_USER_AGENT
       self
     end

--- a/lib/yam/connection.rb
+++ b/lib/yam/connection.rb
@@ -14,7 +14,7 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
+
 require 'faraday'
 require 'yam/constants'
 require 'faraday_middleware/response/mashify'
@@ -39,7 +39,6 @@ module Yam
     end
 
     # Returns a Faraday::Connection object
-    #
     def connection(options = {})
       conn_options = default_options(options)
       clear_cache unless options.empty?
@@ -49,11 +48,7 @@ module Yam
         conn.use Faraday::Response::Mashify
         conn.use FaradayMiddleware::ParseJson
         conn.response :raise_error
-
-        if oauth_token?
-          conn.use FaradayMiddleware::OAuth2, oauth_token
-        end
-
+        conn.use FaradayMiddleware::OAuth2, oauth_token
         conn.request :url_encoded
         conn.adapter adapter
       end

--- a/lib/yam/request.rb
+++ b/lib/yam/request.rb
@@ -14,7 +14,6 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
 
 # Defines HTTP verbs
 module Yam

--- a/lib/yam/version.rb
+++ b/lib/yam/version.rb
@@ -16,5 +16,5 @@
 # permissions and limitations under the License.
 
 module Yam
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,11 +14,13 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
+
 require 'simplecov'
+
 SimpleCov.start do
   add_filter 'spec'
 end
+
 require 'rspec'
 require 'yam'
 require 'webmock/rspec'
@@ -29,25 +31,10 @@ RSpec.configure do |config|
   config.include WebMock::API
   config.order = :rand
   config.color_enabled = true
+
   config.before(:each) do
     Yam.set_defaults
   end
-end
-
-def stub_post(path, endpoint = Yam.endpoint.to_s)
-  stub_request(:post, endpoint + path)
-end
-
-def stub_get(path, endpoint = Yam.endpoint.to_s)
-  stub_request(:get, endpoint + path)
-end
-
-def a_post(path, endpoint = Yam.endpoint.to_s)
-  a_request(:post, endpoint + path)
-end
-
-def a_get(path, endpoint = Yam.endpoint.to_s)
-  a_request(:get, endpoint + path)
 end
 
 def fixture_path

--- a/spec/yam/client_spec.rb
+++ b/spec/yam/client_spec.rb
@@ -14,29 +14,30 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
+
 require 'spec_helper'
+ENDPOINT = Yam::Configuration::DEFAULT_API_ENDPOINT
 
 describe Yam::Client, '#get' do
   it 'makes requests' do
-    stub_get('/custom/get')
-    subject.get('/custom/get')
-    expect(a_get('/custom/get')).to have_been_made
+    stub_request(:get, ENDPOINT)
+    access_token = 'ABC123'
+
+    instance = Yam::Client.new(access_token, ENDPOINT)
+    instance.get('/')
+
+    expect(a_request(:get, ENDPOINT)).to have_been_made
   end
 end
 
 describe Yam::Client, '#post' do
   it 'makes requests' do
-    stub_post('/custom/post')
-    subject.post('/custom/post')
-    expect(a_post('/custom/post')).to have_been_made
-  end
+    stub_request(:post, ENDPOINT)
+    access_token = 'ABC123'
 
-  it 'makes authorized requests' do
-    access_token = '123'
-    Yam.oauth_token = access_token
-    stub_post("/custom/post?access_token=#{access_token}")
-    subject.post('/custom/post')
-    expect(a_post("/custom/post?access_token=#{access_token}")).to have_been_made
+    instance = Yam::Client.new(access_token, ENDPOINT)
+    instance.post('/')
+
+    expect(a_request(:post, ENDPOINT)).to have_been_made
   end
 end

--- a/spec/yam_spec.rb
+++ b/spec/yam_spec.rb
@@ -14,87 +14,76 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
-#
+
 require 'spec_helper'
+
 class TestClass
 end
-describe Yam do
 
-  after do
-    subject.set_defaults
-  end
+describe Yam do
+  # after do
+  #   Yam.set_defaults
+  # end
+
+  ENDPOINT = Yam::Configuration::DEFAULT_API_ENDPOINT
 
   it 'responds to \'new\' message' do
-    subject.should respond_to :new
+    Yam.should respond_to :new
   end
 
-  it 'receives \'new\' and initialize subject::Client instance' do
-    subject.new.should be_a Yam::Client
+  it 'receives \'new\' and initialize an instance' do
+    access_token = 'ABC123'
+
+    instance = Yam.new(access_token, ENDPOINT)
+
+    instance.should be_a Yam::Client
   end
 
   it 'delegates to a Yam::Client instance' do
+    access_token = 'ABC123'
     Yam::Client.any_instance.stubs(:stubbed_method)
 
-    Yam.stubbed_method
+    instance = Yam.new(access_token, ENDPOINT)
+    instance.stubbed_method
 
     Yam::Client.any_instance.should have_received(:stubbed_method)
   end
 
-  it 'responds to \'configure\' message' do
-    subject.should respond_to :configure
-  end
-
   describe 'setting configuration options' do
     it 'returns the default adapter' do
-      subject.adapter.should == Yam::Configuration::DEFAULT_ADAPTER
+      adapter = Yam.adapter
+
+      adapter.should == Yam::Configuration::DEFAULT_ADAPTER
     end
 
     it 'allows setting the adapter' do
-      subject.adapter = :typhoeus
-      subject.adapter.should == :typhoeus
+      Yam.adapter = :typhoeus
+
+      Yam.adapter.should == :typhoeus
     end
 
     it 'returns the default end point' do
-      subject.endpoint.should == Yam::Configuration::DEFAULT_ENDPOINT
+      Yam.endpoint.should == ENDPOINT
     end
 
     it 'allows setting the endpoint' do
-      subject.endpoint = 'http://www.example.com'
-      subject.endpoint.should == 'http://www.example.com'
+      Yam.endpoint = 'http://www.example.com'
+      Yam.endpoint.should == 'http://www.example.com'
     end
 
     it 'returns the default user agent' do
-      subject.user_agent.should == Yam::Configuration::DEFAULT_USER_AGENT
+      Yam.user_agent.should == Yam::Configuration::DEFAULT_USER_AGENT
     end
 
     it 'allows setting the user agent' do
-      subject.user_agent = 'New User Agent'
-      subject.user_agent.should == 'New User Agent'
-    end
+      Yam.user_agent = 'New User Agent'
 
-    it 'does not set oauth token' do
-      subject.oauth_token.should be_nil
-    end
-
-    it 'does not allow setting the oauth token' do
-      subject.oauth_token = 'OT'
-      subject.oauth_token.should == 'OT'
+      Yam.user_agent.should == 'New User Agent'
     end
 
     it 'allows setting the current api client' do
-      subject.should respond_to :api_client=
-      subject.should respond_to :api_client
-    end
-  end
-
-  describe '.configure' do
-    Yam::Configuration::VALID_OPTIONS_KEYS.each do |key|
-      it "should set the #{key}" do
-        Yam.configure do |config|
-          config.send("#{key}=", key)
-          Yam.send(key).should == key
-        end
-      end
+      Yam.should respond_to :api_client=
+      Yam.should respond_to :api_client
     end
   end
 end


### PR DESCRIPTION
- Add endpoint and token to Yam client constructor
- Use Yam instances in tests
- Allow overriding of default API endpoint
- Remove unused `method_missing` in yam.rb
- Remove WebMock helpers from spec_helper.rb
- Rewrite :post and :get tests with raw WebMock matchers

Style:
- Sort required libraries
