### PR TITLE
Add attr_reader for oauth_token

### DIFF
--- a/lib/yam/api.rb
+++ b/lib/yam/api.rb
@@ -25,6 +25,7 @@ module Yam
     include Connection
     include Request
     attr_reader *Configuration::VALID_OPTIONS_KEYS
+    attr_reader :oauth_token, :endpoint
 
     class_eval do
       Configuration::VALID_OPTIONS_KEYS.each do |key|
@@ -46,12 +47,6 @@ module Yam
 
       Configuration::VALID_OPTIONS_KEYS.each do |key|
         send("#{key}=", options[key])
-      end
-    end
-
-    def method_missing(method, *args, &block)
-      if method.to_s.match /^(.*)\?$/
-        return !self.send($1.to_s).nil?
       end
     end
   end

--- a/lib/yam/configuration.rb
+++ b/lib/yam/configuration.rb
@@ -14,6 +14,7 @@
 #
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
+
 require 'yam/version'
 
 module Yam

--- a/lib/yam/connection.rb
+++ b/lib/yam/connection.rb
@@ -34,7 +34,7 @@ module Yam
           USER_AGENT       => user_agent
         },
         :ssl => { :verify => true },
-        :url => options.fetch(:endpoint) { Yam.endpoint }
+        :url => options.fetch(:endpoint) { endpoint }
       }.merge(options)
     end
 

--- a/lib/yam/request.rb
+++ b/lib/yam/request.rb
@@ -30,7 +30,7 @@ module Yam
       conn = connection(options)
       path = (conn.path_prefix + path).gsub(/\/\//,'/') if conn.path_prefix != '/'
 
-      response = conn.send(method,path,params)
+      response = conn.send(method, path, params)
       response.body
     end
   end

--- a/lib/yam/version.rb
+++ b/lib/yam/version.rb
@@ -16,5 +16,5 @@
 # permissions and limitations under the License.
 
 module Yam
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ require 'yam'
 require 'webmock/rspec'
 require 'bourne'
 
+ENDPOINT = Yam::Configuration::DEFAULT_API_ENDPOINT
+
 RSpec.configure do |config|
   config.mock_with :mocha
   config.include WebMock::API

--- a/spec/yam/client_spec.rb
+++ b/spec/yam/client_spec.rb
@@ -16,28 +16,35 @@
 # permissions and limitations under the License.
 
 require 'spec_helper'
-ENDPOINT = Yam::Configuration::DEFAULT_API_ENDPOINT
 
 describe Yam::Client, '#get' do
   it 'makes requests' do
-    stub_request(:get, ENDPOINT)
     access_token = 'ABC123'
+    endpoint_with_token = "#{ENDPOINT}?access_token=#{access_token}"
+    stub_request(:get, endpoint_with_token).
+      with(:headers => { 'Authorization'=>'Token token="ABC123"' })
 
     instance = Yam::Client.new(access_token, ENDPOINT)
     instance.get('/')
 
-    expect(a_request(:get, ENDPOINT)).to have_been_made
+    expect(a_request(:get, endpoint_with_token).
+      with(:headers => { 'Authorization'=>'Token token="ABC123"' })).
+      to have_been_made
   end
 end
 
 describe Yam::Client, '#post' do
   it 'makes requests' do
-    stub_request(:post, ENDPOINT)
     access_token = 'ABC123'
+    endpoint_with_token = "#{ENDPOINT}?access_token=#{access_token}"
+    stub_request(:post, endpoint_with_token).
+      with(:headers => { 'Authorization'=>'Token token="ABC123"' })
 
     instance = Yam::Client.new(access_token, ENDPOINT)
     instance.post('/')
 
-    expect(a_request(:post, ENDPOINT)).to have_been_made
+    expect(a_request(:post, endpoint_with_token).
+      with(:headers => { 'Authorization'=>'Token token="ABC123"' })).
+      to have_been_made
   end
 end

--- a/spec/yam_spec.rb
+++ b/spec/yam_spec.rb
@@ -21,11 +21,9 @@ class TestClass
 end
 
 describe Yam do
-  # after do
-  #   Yam.set_defaults
-  # end
-
-  ENDPOINT = Yam::Configuration::DEFAULT_API_ENDPOINT
+  after do
+    Yam.set_defaults
+  end
 
   it 'responds to \'new\' message' do
     Yam.should respond_to :new
@@ -34,7 +32,7 @@ describe Yam do
   it 'receives \'new\' and initialize an instance' do
     access_token = 'ABC123'
 
-    instance = Yam.new(access_token, ENDPOINT)
+    instance = Yam.new(access_token, Yam::Configuration::DEFAULT_API_ENDPOINT)
 
     instance.should be_a Yam::Client
   end
@@ -43,7 +41,7 @@ describe Yam do
     access_token = 'ABC123'
     Yam::Client.any_instance.stubs(:stubbed_method)
 
-    instance = Yam.new(access_token, ENDPOINT)
+    instance = Yam.new(access_token, Yam::Configuration::DEFAULT_API_ENDPOINT)
     instance.stubbed_method
 
     Yam::Client.any_instance.should have_received(:stubbed_method)
@@ -63,7 +61,7 @@ describe Yam do
     end
 
     it 'returns the default end point' do
-      Yam.endpoint.should == ENDPOINT
+      Yam.endpoint.should == Yam::Configuration::DEFAULT_API_ENDPOINT
     end
 
     it 'allows setting the endpoint' do


### PR DESCRIPTION
- Access token not being sent through URL request
- Add attr_reader for :oauth_token to fix
- Update tests to expect token in url and headers
- Bump version to 0.0.5

Minor edits:
- Remove unused method_missing
- Better use of constants
