### PR TITLE
Fix ruby 1.8.7 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+bin/
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - 1.9.2
   - 1.8.7
   - ree
+before_install:
+  - gem update --system
+  - gem --version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Yam
 ===
 
-![Build Status](https://api.travis-ci.org/yammer/yam.png)
+[![Build Status](https://api.travis-ci.org/yammer/yam.png)](https://travis-ci.org/yammer/yam)
 
 The official Yammer Ruby gem.
 

--- a/lib/yam/api.rb
+++ b/lib/yam/api.rb
@@ -16,9 +16,9 @@
 # permissions and limitations under the License.
 
 # API setup and configuration
-require 'yam/request'
-require 'yam/connection'
 require 'yam/configuration'
+require 'yam/connection'
+require 'yam/request'
 
 module Yam
   class API

--- a/lib/yam/connection.rb
+++ b/lib/yam/connection.rb
@@ -16,10 +16,10 @@
 # permissions and limitations under the License.
 
 require 'faraday'
-require 'yam/constants'
+require 'faraday_middleware/request/oauth2'
 require 'faraday_middleware/response/mashify'
 require 'faraday_middleware/response/parse_json'
-require 'faraday_middleware/request/oauth2'
+require 'yam/constants'
 
 module Yam
   module Connection

--- a/lib/yam/version.rb
+++ b/lib/yam/version.rb
@@ -16,5 +16,5 @@
 # permissions and limitations under the License.
 
 module Yam
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,10 +21,10 @@ SimpleCov.start do
   add_filter 'spec'
 end
 
-require 'rspec'
-require 'yam'
-require 'webmock/rspec'
 require 'bourne'
+require 'rspec'
+require 'webmock/rspec'
+require 'yam'
 
 ENDPOINT = Yam::Configuration::DEFAULT_API_ENDPOINT
 

--- a/yam.gemspec
+++ b/yam.gemspec
@@ -7,8 +7,8 @@ require 'yam/version'
 Gem::Specification.new do |gem|
   gem.name          = 'yam'
   gem.version       = Yam::VERSION
-  gem.authors       = ['Mason Fischer', 'Jessie A. Young']
-  gem.email         = ['mason@thoughtbot.com', 'jessie@apprentice.io']
+  gem.authors       = ['Yammer team at thoughtbot']
+  gem.email         = ['yammer@thoughtbot.com']
   gem.description   = %q{The official Yammer Ruby gem.}
   gem.summary       = %q{A Ruby wrapper for the Yammer REST API}
   gem.homepage      = %q{https://github.com/yammer/yam}
@@ -18,15 +18,16 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'hashie', '~> 1.2.0'
   gem.add_dependency 'faraday', '~> 0.8.1'
   gem.add_dependency 'faraday_middleware', '~> 0.9.0'
+  gem.add_dependency 'hashie', '~> 1.2.0'
+  gem.add_dependency 'json', '~> 1.7.6'
   gem.add_dependency 'multi_json', '~> 1.3'
   gem.add_dependency 'oauth2', '~> 0.8.0'
 
+  gem.add_development_dependency 'bourne', '~> 1.0'
+  gem.add_development_dependency 'mocha', '~> 0.9.8'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'
-  gem.add_development_dependency 'mocha', '~> 0.9.8'
-  gem.add_development_dependency 'bourne', '~> 1.0'
   gem.add_development_dependency 'webmock', '~> 1.9.0'
 end


### PR DESCRIPTION
- Errors noted when running TravisCI on other rubies (https://travis-ci.org/yammer/yam)
- Add json as required gem for ruby 1.8.7
- Add before_install section to run lastest rubies on Travis
- Bumped version number to 0.0.6

Minor:
- Add `.bin/` to .gitignore to exclude binstubs
- Sort required gems/libraries
- Update authorship information
