### PR TITLE
Add script to prepend license to all files

### DIFF
--- a/tools/add_license_header
+++ b/tools/add_license_header
@@ -1,0 +1,16 @@
+# !/usr/bin/env bash
+# adds the license summary to the top of any .rb file that is (1) tracked by
+# git and (2) doesn't already have the header.
+
+cd `git rev-parse --show-toplevel`
+
+ruby_files=`git ls-files | grep '\.rb$'`
+copyright_line=`head -1 tools/license_header`
+
+for f in `grep -L "$copyright_line" $ruby_files`
+do
+    echo "Adding license header to $f"
+    dest="$f.with_header"
+    cat tools/license_header $f > $dest
+    mv $dest $f
+done

--- a/tools/license_header
+++ b/tools/license_header
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
+# IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
+# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.


### PR DESCRIPTION
As per yam_python. Rough script copied below - adjust for the gem.

```

#!/usr/bin/env bash

# tools/add_license_header.sh

# Adds the license summary to the top of any .py file that is (1) tracked by
# git and (2) doesn't already have the header.

cd `git rev-parse --show-toplevel`

python_files=`git ls-files | grep '\.py$'`
copyright_line=`head -1 tools/license_header`

for f in `grep -L "$copyright_line" $python_files`
do
    echo "Adding license header to $f"
    dest="$f.with_header"
    cat tools/license_header $f > $dest
    mv $dest $f
done


# tools/license_header

# Copyright (c) Microsoft Corporation
# All rights reserved.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#   http://www.apache.org/licenses/LICENSE-2.0
#
# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
# ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
# IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR
# PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
#
# See the Apache Version 2.0 License for specific language governing
# permissions and limitations under the License.
```
