### PR TITLE
Fixing typo in open_graph_object api

### DIFF
--- a/lib/yammer/api/open_graph_object.rb
+++ b/lib/yammer/api/open_graph_object.rb
@@ -39,7 +39,7 @@ module Yammer
       #  :image     => 'https://microsoft.com/global/images/test.jpg'
       # })
       def create_open_graph_object(url, props={})
-        post("/api/v1/open_graph_objects", { :url => url, :properites => props })
+        post("/api/v1/open_graph_objects", { :url => url, :properties => props })
       end
 
       # Subscribes the current user to the open graph object with the request id.

--- a/spec/api/open_graph_object_spec.rb
+++ b/spec/api/open_graph_object_spec.rb
@@ -41,7 +41,7 @@ describe Yammer::Api::Search do
       }
       subject.should_receive(:post).with('/api/v1/open_graph_objects', {
         :url=>"http://www.example.com",
-        :properites => {
+        :properties => {
           :site_name => "Microsoft",
           :image => "https://example.com/global/images/test.jpg"
         }


### PR DESCRIPTION
Fixed Issue# 28

Properties hash in the create_open_graph_object method was ignored due to a typo.
