### PR TITLE
Add access the the /user/in_group method from the REST API

### DIFF
--- a/lib/yammer/api/user.rb
+++ b/lib/yammer/api/user.rb
@@ -163,6 +163,19 @@ module Yammer
       def users_followed_by(id)
         get("/api/v1/users/followed_by/#{id}")
       end
+
+      # @rate_limited Yes
+      # @authentication Requires user context
+      # @raise  [Yammer::Error::Unauthorized] Error raised when supplied user credentials are not valid.
+      # @return [Yammer::ApiResponse]
+      # @param  id [Integer] the ID of the group for which you want to get the members of
+      # @param  opts [Hash] A customizable set of opts.
+      # @option opts [Integer] :page
+      # @example Fetch users in a group that the authenticated user is in
+      #   Yammer.users_in_group(1)
+      def users_in_group(id, opts={})
+        get("/api/v1/users/in_group/#{id}", opts)
+      end
     end
   end
 end

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -105,4 +105,16 @@ describe Yammer::Api::User do
       @client.users_followed_by(4)
     end
   end
+
+  describe 'users_in_group' do
+    it 'makes an http request without' do
+      @client.should_receive(:get).with('/api/v1/users/in_group/5', {})
+      @client.users_in_group(5)
+    end
+ 
+    it 'makes an http request with optional parameters' do
+      @client.should_receive(:get).with('/api/v1/users/in_group/5', {:page => 2})
+      @client.users_in_group(5, {:page => 2})
+    end
+  end
 end


### PR DESCRIPTION
The /user/in_group method wasn't available via the Ruby SDK.  
