### PR TITLE
[User API] Options support for 'users_following' and 'users_followed_by' calls

### DIFF
--- a/lib/yammer/api/user.rb
+++ b/lib/yammer/api/user.rb
@@ -147,10 +147,12 @@ module Yammer
       # @raise  [Yammer::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [Yammer::ApiResponse]
       # @param  id [Integer] the ID of the user whose followers you want to get
+      # @param  opts [Hash] A customizable set of opts.
+      # @option opts [Integer] :page
       # @example Fetch users from the authenticated user's network following user whose ID is provided
       #   Yammer.users_following(1)
-      def users_following(id)
-        get("/api/v1/users/following/#{id}")
+      def users_following(id, opts={})
+        get("/api/v1/users/following/#{id}", opts)
       end
 
       # @rate_limited Yes
@@ -158,10 +160,12 @@ module Yammer
       # @raise  [Yammer::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [Yammer::ApiResponse]
       # @param  id [Integer] the ID of the user for whom you want to get the users being followed
+      # @param  opts [Hash] A customizable set of opts.
+      # @option opts [Integer] :page
       # @example Fetch users from the authenticated user's network followed by the user whose ID is provided
       #   Yammer.users_followed(1)
-      def users_followed_by(id)
-        get("/api/v1/users/followed_by/#{id}")
+      def users_followed_by(id, opts={})
+        get("/api/v1/users/followed_by/#{id}", opts)
       end
 
       # @rate_limited Yes

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -94,15 +94,15 @@ describe Yammer::Api::User do
 
   describe 'users_following' do
     it 'makes an http request' do
-      @client.should_receive(:get).with('/api/v1/users/following/3')
-      @client.users_following(3)
+      @client.should_receive(:get).with('/api/v1/users/following/3', {:page => 2})
+      @client.users_following(3, page: 2)
     end
   end
 
   describe 'users_followed_by' do
     it 'makes an http request' do
-      @client.should_receive(:get).with('/api/v1/users/followed_by/4')
-      @client.users_followed_by(4)
+      @client.should_receive(:get).with('/api/v1/users/followed_by/4', {:page => 2})
+      @client.users_followed_by(4, page: 2)
     end
   end
 


### PR DESCRIPTION
Use case: enumerate all the followers 
(we have to specify the `page:` option)

```ruby
def all_followers(user_id)
  page = 0
  followers = []
  loop do
    body = Yammer.users_following(user_id, page: page).body
    followers.concat(body[:users])
    break unless body[:more_available]
    page += 1
  end
  followers
end
```