### PR TITLE
Remove hard 'oj' dependency

### DIFF
--- a/yam.gemspec
+++ b/yam.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
   s.cert_chain       = ['certs/public.pem']
   s.signing_key      = File.expand_path("~/.gem/certs/private_key.pem") if $0 =~ /gem\z/
 
-  s.add_dependency 'oj', '~> 2.14'
   s.add_dependency 'multi_json', '~> 1.8'
   s.add_dependency 'rest-client', '~> 1.8'
   s.add_dependency 'addressable', '~> 2.4'


### PR DESCRIPTION
This makes it incompatible with JRuby, yet users can still use 'oj' through 'multi_json'.
