### PR TITLE
Use Yammer::Error rather than RestClient Exception messages

### DIFF
--- a/lib/yammer/http_adapter.rb
+++ b/lib/yammer/http_adapter.rb
@@ -84,7 +84,7 @@ class HttpAdapter
       result = Yammer::ApiResponse.new(resp.headers, resp.body, resp.code)
     rescue => e
       if e.is_a?(RestClient::ExceptionWithResponse)
-        e.response
+        Yammer::Error.from_status(e.http_code)
       else
         raise e
       end

--- a/spec/http_adapter_spec.rb
+++ b/spec/http_adapter_spec.rb
@@ -28,7 +28,39 @@ describe Yammer::HttpAdapter do
     end
   end
 
-  context "initialization" do 
+  describe "#send_request" do
+    context 'when resource is found' do
+      subject { @conn = Yammer::HttpAdapter.new('https://www.yammer.com') }
+      let(:uri) { 'https://www.yammer.com/foo' }
+      before    { stub_request(:get, uri).to_return(status: 200, body: nil) }
+      it "returns a Yammer APIResponse" do
+        response = subject.send_request(:get, "/foo")
+        expect(response).to be_a(Yammer::ApiResponse)
+      end
+    end
+
+    context 'when resource is not found' do
+      subject { @conn = Yammer::HttpAdapter.new('https://www.yammer.com') }
+      let(:uri) { 'https://www.yammer.com/foo' }
+      before    { stub_request(:get, uri).to_return(status: 404, body: nil) }
+      it "returns a Yammer APIResponse" do
+        response = subject.send_request(:get, "/foo")
+        expect(response).to eq(Yammer::Error::NotFound)
+      end
+    end
+
+    context 'when resource is unauthorized' do
+      subject { @conn = Yammer::HttpAdapter.new('https://www.yammer.com') }
+      let(:uri) { 'https://www.yammer.com/foo' }
+      before    { stub_request(:get, uri).to_return(status: 401, body: nil) }
+      it "returns a Yammer APIResponse" do
+        response = subject.send_request(:get, "/foo")
+        expect(response).to eq(Yammer::Error::Unauthorized )
+      end
+    end
+  end
+
+  context "initialization" do
     context "with user options" do
 
       before do


### PR DESCRIPTION
This seeks to fix two reported issues with our Yammer client. 
https://github.com/yammer/yam/issues/46
https://github.com/yammer/yam/issues/34

Currently when a request is not successful it defaults to showing the exception message (which is generally blank and not helpful). 

